### PR TITLE
## [1.0.4]

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,19 +1,19 @@
 # Changelog
 
-## [1.0.3]
+## [1.0.4]
+### Fixes
+- Remove unused .asmdef file for runtime
 
+## [1.0.3]
 ### Fixes
 - Fix the menu item when there is not selected any file to slicing
 
 ## [1.0.2]
-
 ### Fixes
 - Fix Assembly Definitions
 
 ## [1.0.1]
-
 ### Updates
 - Change logic from auto-slicing to slice by spriteborders.
-
 ### Improvements
 - Code refactoring.

--- a/OnionRing.asmdef
+++ b/OnionRing.asmdef
@@ -1,3 +1,0 @@
-﻿{
-	"name": "OnionRing"
-}

--- a/OnionRing.asmdef.meta
+++ b/OnionRing.asmdef.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 598e0f630979a403ea51fada9079f169
-AssemblyDefinitionImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev.fd.onionring",
   "displayName": "OnionRing",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "unity": "2019.4",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
### Fixes
- Remove unused .asmdef file for runtime